### PR TITLE
Updated fontproof to 1.3.3

### DIFF
--- a/packages.lua
+++ b/packages.lua
@@ -7,7 +7,7 @@ local Catalogue = {
   fontproof = {
     description = "A font design testing class",
     repository  = "https://github.com/silnrsi/fontproof",
-    version = "v1.3.2"
+    version = "v1.3.3"
   },
   ftmlsile = {
     description = "A class for font testing using content in FTML format",


### PR DESCRIPTION
fixes escaping issues and also has various cleanups kindly provided by @alerque. 